### PR TITLE
Inventory: Forget inventory after round change.

### DIFF
--- a/gamemodes/homigrad/homigrad.txt
+++ b/gamemodes/homigrad/homigrad.txt
@@ -14,6 +14,7 @@
 			"help"		"Spawns all players with a physgun & ability to use the Spawn Menu."
 			"type"		"CheckBox"
 			"default"	"0"
+			"singleplayer"
 		}
 		2
 		{
@@ -22,14 +23,16 @@
 			"help"		"Homicide is the only round type queued. Other gamemodes like TDM, Capture The Point, etc, are not queued."
 			"type"		"CheckBox"
 			"default"	"0"
+			"singleplayer"
 		}
 		3
 		{
 			"name"		"hg_SearchTime"
-			"text"		"Inv. Search Time (Sec 0-10)"
+			"text"		"Inventory Search Time (seconds)"
 			"help"		"Items in a player's inventory will appear after a given time (between 0 and 10)"
 			"type"		"Numeric"
-			"default"	"0"
+			"default"	"2"
+			"singleplayer"
 		}
 		4
 		{
@@ -46,6 +49,7 @@
 			"help"		"If enabled, Police will be alerted to who the traitors are when they arrive."
 			"type"		"CheckBox"
 			"default"	"0"
+			"singleplayer"
 		}
 	}
 }

--- a/gamemodes/homigrad/homigrad.txt
+++ b/gamemodes/homigrad/homigrad.txt
@@ -41,6 +41,7 @@
 			"help"		"Enables/Disables Looting Alive Players."
 			"type"		"CheckBox"
 			"default"	"1"
+			"singleplayer"
 		}
 		5
 		{

--- a/gamemodes/homigrad/homigrad.txt
+++ b/gamemodes/homigrad/homigrad.txt
@@ -14,7 +14,6 @@
 			"help"		"Spawns all players with a physgun & ability to use the Spawn Menu."
 			"type"		"CheckBox"
 			"default"	"0"
-			"singleplayer"
 		}
 		2
 		{
@@ -23,25 +22,30 @@
 			"help"		"Homicide is the only round type queued. Other gamemodes like TDM, Capture The Point, etc, are not queued."
 			"type"		"CheckBox"
 			"default"	"0"
-			"singleplayer"
 		}
 		3
 		{
 			"name"		"hg_SearchTime"
-			"text"		"Inventory Search Time (seconds)"
+			"text"		"Inv. Search Time (Sec 0-10)"
 			"help"		"Items in a player's inventory will appear after a given time (between 0 and 10)"
 			"type"		"Numeric"
-			"default"	"2"
-			"singleplayer"
+			"default"	"0"
 		}
 		4
+		{
+			"name"		"hg_LootAlive"
+			"text"		"Loot Alive Players"
+			"help"		"Enables/Disables Looting Alive Players."
+			"type"		"CheckBox"
+			"default"	"1"
+		}
+		5
 		{
 			"name"		"hg_TellPoliceWhoTraitorsAre"
 			"text"		"Announce Traitors on Police Spawn (Not realized for now)"
 			"help"		"If enabled, Police will be alerted to who the traitors are when they arrive."
 			"type"		"CheckBox"
 			"default"	"0"
-			"singleplayer"
 		}
 	}
 }

--- a/lua/homigrad_scr/game/tier_1/inventory_cl.lua
+++ b/lua/homigrad_scr/game/tier_1/inventory_cl.lua
@@ -94,7 +94,7 @@ net.Receive("inventory", function()
 			net.WriteEntity(lootEnt)
 		net.SendToServer()
 	end
-
+	-- Should do the job
 	local lootingTime = math.Clamp(GetConVar("hg_SearchTime"):GetInt(), 0, 10)
 	local targetID = IsValid(lootEnt) and lootEnt:SteamID64()
 	local corner = 6

--- a/lua/homigrad_scr/game/tier_1/inventory_cl.lua
+++ b/lua/homigrad_scr/game/tier_1/inventory_cl.lua
@@ -69,8 +69,6 @@ net.Receive("inventory", function()
 
 	local items_ammo = net.ReadTable()
 
-	-- if #items == 0 and #items_ammo == 0 then return end -- wtf
-
 	items.weapon_hands = nil
 
 	panel = vgui.Create("DFrame")
@@ -97,7 +95,6 @@ net.Receive("inventory", function()
 		net.SendToServer()
 	end
 
-	-- Should do the job
 	local lootingTime = math.Clamp(GetConVar("hg_SearchTime"):GetInt(), 0, 10)
 	local targetID = IsValid(lootEnt) and lootEnt:SteamID64()
 	local corner = 6
@@ -215,7 +212,6 @@ net.Receive("inventory", function()
 	end)
 
 	-- "Forget" target's inventory after 1 min
-	timer.Simple(60, function()
-		hg_searched[targetID] = nil
-	end)
+	timer.Simple(60, function() hg_searched[targetID] = nil end)
+	hook.Add("PostCleanupMap", "Forget_Anyones_Inventory", function() hg_searched[targetID] = nil end)
 end)


### PR DESCRIPTION
Player should forget anyone's inventory now on new round start.
Update: Added "hg_lootalive" for toggle option in homigrad.txt (Default: 1)