### PR TITLE
Not to be a pronoun pete but these pronouns aren't neutral.

### DIFF
--- a/gamemodes/homigrad/content/resource/localization/en/homigrad.properties
+++ b/gamemodes/homigrad/content/resource/localization/en/homigrad.properties
@@ -282,13 +282,13 @@ hg.xm1014.inst=Automatic shotgun straight from Italy.\nUses 12/70 Gauge ammo.
 ## Melee
 hg.hands.name=Hands
 hg.hands.inst=LMB - Ready/Attack\nRMB - Block/Grab\nR - Chill, bro.
-hg.hands.nopulse=No pulse. He's dead...
-hg.hands.cpr=No pulse. He's still alive, try doing CPR, maybe it will help...
-hg.hands.great=He's in excellent condition.
+hg.hands.nopulse=No pulse. They're dead...
+hg.hands.cpr=No pulse. They're still alive, try doing CPR, maybe it will help...
+hg.hands.great=They're in excellent condition.
 hg.hands.rough=A little beat up, but alive.
-hg.hands.bad=He's not well, but he can live.
-hg.hands.barely=He's barely alive, he needs help now.
-hg.hands.uncon=He's unconscious.
+hg.hands.bad=They're not well, but they can live.
+hg.hands.barely=They're barely alive, they need help now.
+hg.hands.uncon=They're unconscious.
 hg.hands.cantsave=There's nothing we can do...
 
 hg.handsfast.name=Fast Hands


### PR DESCRIPTION
English Pronouns were all masculine, now they are neutral!